### PR TITLE
✨[Feat] 카카오 연동 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/cafehub/backend/common/filter/CorsFilter.java
+++ b/src/main/java/com/cafehub/backend/common/filter/CorsFilter.java
@@ -36,6 +36,7 @@ public class CorsFilter implements Filter {
 
 
 
+
         if ("OPTIONS".equalsIgnoreCase(httpServletRequest.getMethod())) {
             log.info("preflight request 처리");
             httpServletResponse.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/cafehub/backend/common/filter/jwt/JwtThreadLocalStorage.java
+++ b/src/main/java/com/cafehub/backend/common/filter/jwt/JwtThreadLocalStorage.java
@@ -36,5 +36,8 @@ public class JwtThreadLocalStorage {
         return jwtPayloadReader.getNickname(jwtAccessTokenHolder.get());
     }
 
+    public String getOAuthProviderNameFromJwt(){
+        return jwtPayloadReader.getProvider(jwtAccessTokenHolder.get());
+    }
 
 }

--- a/src/main/java/com/cafehub/backend/domain/member/login/controller/LoginController.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/controller/LoginController.java
@@ -1,14 +1,13 @@
 package com.cafehub.backend.domain.member.login.controller;
 
+import com.cafehub.backend.common.dto.ResponseDTO;
+import com.cafehub.backend.common.filter.jwt.JwtThreadLocalStorage;
 import com.cafehub.backend.domain.member.login.service.OAuth2LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -17,7 +16,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class LoginController {
 
-    public static final String MEMBER_SERVICE_SUFFIX = "LoginService";
+
+    public static final String Login_SERVICE_SUFFIX = "LoginService";
+
+    private final JwtThreadLocalStorage jwtThreadLocalStorage;
 
     private final Map<String, OAuth2LoginService> oAuth2LoginServiceMap;
 
@@ -25,12 +27,12 @@ public class LoginController {
     @GetMapping("/api/member/login/{provider}")
     public ResponseEntity<Void> login(@PathVariable("provider") String provider){
 
-        OAuth2LoginService memberService = oAuth2LoginServiceMap.get(provider + MEMBER_SERVICE_SUFFIX);
+        OAuth2LoginService loginService = oAuth2LoginServiceMap.get(provider + Login_SERVICE_SUFFIX);
 
         log.info("로그인 요청 발생, 사용자가 프론트에서 {}로 로그인 하기 버튼을 누름", provider);
 
         return ResponseEntity.status(HttpStatus.FOUND)
-                .header("Location", memberService.getLoginPageUrl(provider))
+                .header("Location", loginService.getLoginPageUrl(provider))
                 .build();
     }
 
@@ -41,11 +43,11 @@ public class LoginController {
     public ResponseEntity<Void> OAuthCallback(@RequestParam ("code") String authorizationCode,
                                               @RequestParam ("state") String provider){
 
-        OAuth2LoginService memberService = oAuth2LoginServiceMap.get(provider + MEMBER_SERVICE_SUFFIX);
+        OAuth2LoginService loginService = oAuth2LoginServiceMap.get(provider + Login_SERVICE_SUFFIX);
 
         log.info("사용자가 카카오에 로그인했고 {}에서 CafeHub에 사용자를 통해서 리다이렉트로 콜백 성공", provider);
 
-        Map<String, String> jwtTokens = memberService.loginWithOAuthAndIssueJwt(authorizationCode);
+        Map<String, String> jwtTokens = loginService.loginWithOAuthAndIssueJwt(authorizationCode);
 
         String jwtAccessToken = jwtTokens.get("jwtAccessToken");
         String jwtRefreshToken = jwtTokens.get("jwtRefreshToken");
@@ -54,6 +56,31 @@ public class LoginController {
                 .header("Set-Cookie", "JwtAccessToken=" + "Bearer " + jwtAccessToken + "; Path=/; Max-Age=3600; SameSite=Lax; Secure")
                 .header("Set-Cookie", "JwtRefreshToken=" + "Bearer " +  jwtRefreshToken + "; Path=/; Max-Age=604800; SameSite=Lax; HttpOnly; Secure")
                 .header("Location", "http://localhost:3000/OAuthCallback")
+                .build();
+    }
+
+
+
+    @PostMapping("/api/auth/member/logout")
+    public ResponseEntity<ResponseDTO<?>> providerLogout (){
+
+        // 1. CafeHub말고 카카오 계정도 로그아웃 할지 연동시켜줘야함
+
+        OAuth2LoginService loginService = oAuth2LoginServiceMap.get(jwtThreadLocalStorage.getOAuthProviderNameFromJwt() + Login_SERVICE_SUFFIX);
+
+        return ResponseEntity.ok(ResponseDTO.success(loginService.getProviderLogoutPageUrl()));
+    }
+
+    @GetMapping("/serviceLogout")
+    public ResponseEntity<ResponseDTO<Void>> serviceLogout(@RequestParam("state") String provider){
+
+        // 확장을 위해 남겨둠, DB에서 사용자 AuthInfo 와 관련해서 OAuth2 Refresh Token 제거 등의 추후 처리가 필요하다던가 등등
+        OAuth2LoginService loginService = oAuth2LoginServiceMap.get(provider + Login_SERVICE_SUFFIX);
+
+    
+            return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Set-Cookie", "JwtRefreshToken=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly; Secure")
+                .header("Location", "http://localhost:3000/Logout")
                 .build();
     }
 

--- a/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtPayloadReader.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtPayloadReader.java
@@ -30,4 +30,8 @@ public class JwtPayloadReader {
     public Date getExpiration(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration();
     }
+
+    public String getProvider(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("OAuthProvider", String.class);
+    }
 }

--- a/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtProvider.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtProvider.java
@@ -15,8 +15,8 @@ public class JwtProvider {
 
     private final SecretKey secretKey;
 
-    private static final long ACEESS_TOKEN_EXPIRATION_MS = 60 * 60 * 1000; // 1시간
-    private static final long REFRESH_TOKEN_EXPIRATION_MS = 60 * 60 * 1000 *24; // 24시간
+    private static final long ACCESS_TOKEN_EXPIRATION_MS = 1000 * 60 * 60 * 6; // 1000ms = 1초, 1초 *60 *60 *12 = 6시간
+    private static final long REFRESH_TOKEN_EXPIRATION_MS = 1000 * 60 * 60 * 24; // 24시간
 
 
     public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
@@ -29,8 +29,9 @@ public class JwtProvider {
                 .claim("tokenType", "jwt_access")
                 .claim("nickname", jwtTokenPayloadCreateDTO.getNickname())
                 .claim("memberId", jwtTokenPayloadCreateDTO.getMemberId())
+                .claim("OAuthProvider", jwtTokenPayloadCreateDTO.getProvider())
                 .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + ACEESS_TOKEN_EXPIRATION_MS))
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_MS))
                 .signWith(secretKey)
                 .compact();
     }
@@ -39,6 +40,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .claim("tokenType", "jwt_Refresh")
                 .claim("memberId", jwtTokenPayloadCreateDTO.getMemberId())
+                .claim("OAuthProvider", jwtTokenPayloadCreateDTO.getProvider())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_MS))
                 .signWith(secretKey)

--- a/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtTokenPayloadCreateDTO.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/jwt/JwtTokenPayloadCreateDTO.java
@@ -14,4 +14,6 @@ public class JwtTokenPayloadCreateDTO {
 
     private String nickname;
 
+    private String provider;
+
 }

--- a/src/main/java/com/cafehub/backend/domain/member/login/service/KakaoLoginService.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/service/KakaoLoginService.java
@@ -27,10 +27,14 @@ import java.util.Map;
 @Transactional
 public class KakaoLoginService implements OAuth2LoginService {
 
+    private static final String KAKAO_OAUTH_PROVIDER_NAME = "kakao";
+
     private final String clientId;
     private final String redirectUri;
     private final String clientSecret;
     private final String loginPageUrl;
+
+    private final String logoutRedirectUrl;
 
     private final RestClient restClient;
     private final LoginRepository loginRepository;
@@ -43,12 +47,14 @@ public class KakaoLoginService implements OAuth2LoginService {
                              @Value("${kakao.clientId}") String clientId,
                              @Value("${kakao.redirectUri}") String redirectUri,
                              @Value("${kakao.clientSecret}") String clientSecret,
+                             @Value("${kakao.logoutRedirectUrl}") String logoutRedirectUrl,
                              RestClient restClient, LoginRepository loginRepository,
                              AuthInfoRepository authInfoRepository, JwtProvider jwtProvider, JwtPayloadReader jwtPayloadReader) {
 
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.clientSecret = clientSecret;
+        this.logoutRedirectUrl = logoutRedirectUrl;
         this.restClient = restClient;
         this.authInfoRepository = authInfoRepository;
         this.jwtPayloadReader = jwtPayloadReader;
@@ -81,6 +87,7 @@ public class KakaoLoginService implements OAuth2LoginService {
 
         return issueJwtTokens(userInfo.getAppId());
     }
+
 
 
     private KakaoOAuthTokenResponseDTO getOAuthTokens(String authorizationCode) {
@@ -136,7 +143,7 @@ public class KakaoLoginService implements OAuth2LoginService {
 
             AuthInfo newMemberAuthInfo = AuthInfo.builder()
                     .appId(appId)
-                    .provider("kakao")
+                    .provider(KAKAO_OAUTH_PROVIDER_NAME)
                     .build();
 
 
@@ -176,6 +183,7 @@ public class KakaoLoginService implements OAuth2LoginService {
         JwtTokenPayloadCreateDTO jwtTokenPayloadCreateDTO = JwtTokenPayloadCreateDTO.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
+                .provider(KAKAO_OAUTH_PROVIDER_NAME)
                 .build();
 
 
@@ -194,5 +202,19 @@ public class KakaoLoginService implements OAuth2LoginService {
 
         return jwtTokens;
     }
+
+
+
+    @Override
+    public String getProviderLogoutPageUrl() {
+
+        log.info("사용자가 카카오 계정 로그아웃 할지 선택");
+
+        return "https://kauth.kakao.com/oauth/logout?" +
+                "client_id="+ clientId + "&" +
+                "logout_redirect_uri=" + logoutRedirectUrl + "&"
+                + "state=kakao";
+    }
+
 
 }

--- a/src/main/java/com/cafehub/backend/domain/member/login/service/OAuth2LoginService.java
+++ b/src/main/java/com/cafehub/backend/domain/member/login/service/OAuth2LoginService.java
@@ -7,4 +7,7 @@ public interface OAuth2LoginService {
     String getLoginPageUrl(String provider);
 
     Map<String, String> loginWithOAuthAndIssueJwt(String authorizationCode);
+
+    String getProviderLogoutPageUrl();
+
 }


### PR DESCRIPTION
사용자가 한개로 통일 되어있는 로그아웃 버튼을 누를시

어떤 Provider의 OAuth 서비스인지 확인해서 
해당 Provider가 Kakao인 경우의 로그아웃 서비스를 구현

이 때, CafeHub에서만 로그아웃 후 카카오 계정에 대한 로그인을 사용자의 웹브라우저에 남겨 둘 수도 있고
CafeHub, 카카오 계정 둘 다에 대한 로그아웃도 가능함