### PR TITLE
✨[Feat] 회원가입시 프로필 사진 자동 설정 기능 구현

### DIFF
--- a/src/main/java/com/cafehub/backend/domain/member/mypage/service/MemberService.java
+++ b/src/main/java/com/cafehub/backend/domain/member/mypage/service/MemberService.java
@@ -23,8 +23,9 @@ public class MemberService {
 
         Member member = memberRepository.findById(jwtThreadLocalStorage.getMemberIdFromJwt()).get();
 
+
         MyPageResponseDTO res = MyPageResponseDTO.builder().
-                memberImgUrl(member.getProfileImg().getUrl()).
+                memberImgUrl(member.getProfileImg() != null ? member.getProfileImg().getUrl() : null).
                 nickname(member.getNickname()).
                 email(member.getEmail()).
                 build();


### PR DESCRIPTION
신규 회원 가입시 카카오 프로필 이미지 조회에 동의 했다면 카카오 프로필 이미지를 그대로 프로필 사진으로 사용하고,
동의하지 않은 회원이라면 기본 프로필 이미지를 프로필 이미지로 조정함.

이 때 회원가입시 사용에 동의하지 않았다면 프로필 이미지가 없어서 DB에 회원의 기본 이미지가 null로 저장되고 
이미지 url이 null 인 사용자는 프론트에서 기본 프로필 이미지로 처리함 