### PR TITLE
🚑[Fix] 닉네임 변경시 리뷰작성자 닉네임 변경 안되는 에러 수정

### DIFF
--- a/src/main/java/com/cafehub/backend/domain/member/mypage/service/MemberService.java
+++ b/src/main/java/com/cafehub/backend/domain/member/mypage/service/MemberService.java
@@ -8,6 +8,8 @@ import com.cafehub.backend.domain.member.mypage.dto.request.MemberNicknameUpdate
 import com.cafehub.backend.domain.member.mypage.dto.response.MyPageResponseDTO;
 import com.cafehub.backend.domain.member.mypage.dto.response.MyPageUpdateResponseDTO;
 import com.cafehub.backend.domain.member.mypage.repository.MemberRepository;
+import com.cafehub.backend.domain.review.entity.Review;
+import com.cafehub.backend.domain.review.repository.ReviewRepository;
 import io.awspring.cloud.s3.S3Operations;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +37,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    private final ReviewRepository reviewRepository;
+
 
     @Transactional(readOnly = true)
     public ResponseDTO<MyPageResponseDTO> getMyPage() {
@@ -58,7 +62,9 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).get();
         member.updateNickname(requestDTO.getNickname());
 
-        // 리뷰의 Author도 수정해야함
+        Review review = reviewRepository.findById(memberId).get();
+        review.updateWriter(requestDTO.getNickname());
+
 
         return ResponseDTO.success(new MyPageUpdateResponseDTO(memberId));
     }

--- a/src/main/java/com/cafehub/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/cafehub/backend/domain/review/entity/Review.java
@@ -51,4 +51,8 @@ public class Review extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewPhoto> reviewPhotos = new ArrayList<>();
+
+    public void updateWriter(String writer){
+        this.writer = writer;
+    }
 }

--- a/src/main/java/com/cafehub/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/cafehub/backend/domain/review/service/ReviewService.java
@@ -126,9 +126,11 @@ public class ReviewService {
         Slice<ReviewDetail> reviewDetails = reviewRepository.findReviewsBySlice(requestDTO);
 
 
+
         if (jwtThreadLocalStorage.isLoginMember()){
 
-            String loginMemberNickname = jwtThreadLocalStorage.getMemberNicknameFromJwt();
+            Member loginMember = memberRepository.findById(jwtThreadLocalStorage.getMemberIdFromJwt()).get();
+            String loginMemberNickname = loginMember.getNickname();
 
             for (ReviewDetail rd : reviewDetails){
 


### PR DESCRIPTION
 사용자가 마이페이지에서 닉네임을 변경할 때 사용자가 작성했던 리뷰가 있으면 해당 리뷰의 작성자도 변경  